### PR TITLE
Replace dash in flag name with underscore in env var

### DIFF
--- a/globalconf.go
+++ b/globalconf.go
@@ -166,6 +166,7 @@ func getEnv(envPrefix, flagSetName, flagName string) string {
 		flagSetName += "_"
 	}
 	flagName = strings.Replace(flagName, ".", "_", -1)
+	flagName = strings.Replace(flagName, "-", "_", -1)
 	envKey := strings.ToUpper(envPrefix + flagSetName + flagName)
 	return os.Getenv(envKey)
 }

--- a/globalconf_test.go
+++ b/globalconf_test.go
@@ -67,6 +67,24 @@ func TestParse_Global(t *testing.T) {
 	}
 }
 
+func TestParse_DashConversion(t *testing.T) {
+	resetForTesting("")
+
+	flagFooBar := flag.String("foo-bar", "", "")
+	os.Setenv("PREFIX_FOO_BAR", "baz")
+
+	opts := Options{EnvPrefix: "PREFIX_"}
+	conf, err := NewWithOptions(&opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conf.ParseAll()
+
+	if *flagFooBar != "baz" {
+		t.Errorf("flagFooBar found %v, expected 5.5", *flagFooBar)
+	}
+}
+
 func TestParse_GlobalWithDottedFlagname(t *testing.T) {
 	resetForTesting("")
 	os.Setenv(envTestPrefix+"SOME_VALUE", "some-value")


### PR DESCRIPTION
Environment variables with dashes in them aren't too friendly. How about we replace the dash with an underscore?
