### PR TITLE
Use glacjay/goini instead of rakyll/goini

### DIFF
--- a/globalconf.go
+++ b/globalconf.go
@@ -8,7 +8,7 @@ import (
 	"path"
 	"strings"
 
-	ini "github.com/rakyll/goini"
+	ini "github.com/glacjay/goini"
 )
 
 const (


### PR DESCRIPTION
Hi there.  I noticed that the current version of your goini fork is now subsumed by the original.  Here's a tiny, tiny patch to use the original again.

Thanks!

Tim.