### PR TITLE
Issue 16 empty envvars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: go
-go: 1.2
+go: 1.5

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Custom flagset values should be provided in their own segment. Getting back to t
 
 If an EnvPrefix is provided, environment variables will take precedence over values in the configuration file.
 Set the `EnvPrefix` option when calling `globalconf.NewWithOptions`.
-An `EnvPrefix` will only be used if it is a non-empty string.
 Command line flags will override the environment variables.
 
 ~~~ go

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Custom flagset values should be provided in their own segment. Getting back to t
 
 If an EnvPrefix is provided, environment variables will take precedence over values in the configuration file.
 Set the `EnvPrefix` option when calling `globalconf.NewWithOptions`.
+An `EnvPrefix` will only be used if it is a non-empty string.
 Command line flags will override the environment variables.
 
 ~~~ go

--- a/globalconf.go
+++ b/globalconf.go
@@ -104,8 +104,7 @@ func (g *GlobalConf) Delete(flagSetName, flagName string) error {
 // if the flag is not in the file.
 func (g *GlobalConf) ParseSet(flagSetName string, set *flag.FlagSet) {
 	set.VisitAll(func(f *flag.Flag) {
-		val, exists := getEnv(g.EnvPrefix, flagSetName, f.Name)
-		if exists {
+		if val, ok := getEnv(g.EnvPrefix, flagSetName, f.Name); ok {
 			set.Set(f.Name, val)
 			return
 		}
@@ -127,13 +126,12 @@ func (g *GlobalConf) Parse() {
 			alreadySet[f.Name] = true
 		})
 		set.VisitAll(func(f *flag.Flag) {
-			// if not already set, set it from dict if exists
+			// if not already set, set it from dict if ok
 			if alreadySet[f.Name] {
 				return
 			}
 
-			val, exists := getEnv(g.EnvPrefix, name, f.Name)
-			if exists {
+			if val, ok := getEnv(g.EnvPrefix, name, f.Name); ok {
 				set.Set(f.Name, val)
 				return
 			}

--- a/globalconf.go
+++ b/globalconf.go
@@ -169,7 +169,7 @@ func getEnv(envPrefix, flagSetName, flagName string) (string, bool) {
 	return os.LookupEnv(envKey)
 }
 
-// Register register a flag set to be parsed. Register all flag sets
+// Register registers a flag set to be parsed. Register all flag sets
 // before calling this function. flag.CommandLine is automatically
 // registered.
 func Register(flagSetName string, set *flag.FlagSet) {

--- a/globalconf.go
+++ b/globalconf.go
@@ -98,14 +98,14 @@ func (g *GlobalConf) Delete(flagSetName, flagName string) error {
 	return nil
 }
 
-// Parses the config file for the provided flag set.
+// ParseSet parses the config file for the provided flag set.
 // If the flags are already set, values are overwritten
 // by the values in the config file. Defaults are not set
 // if the flag is not in the file.
 func (g *GlobalConf) ParseSet(flagSetName string, set *flag.FlagSet) {
 	set.VisitAll(func(f *flag.Flag) {
-		val := getEnv(g.EnvPrefix, flagSetName, f.Name)
-		if val != "" {
+		val, exists := getEnv(g.EnvPrefix, flagSetName, f.Name)
+		if exists {
 			set.Set(f.Name, val)
 			return
 		}
@@ -117,7 +117,7 @@ func (g *GlobalConf) ParseSet(flagSetName string, set *flag.FlagSet) {
 	})
 }
 
-// Parses all the registered flag sets, including the command
+// Parse parses all the registered flag sets, including the command
 // line set and sets values from the config file if they are
 // not already set.
 func (g *GlobalConf) Parse() {
@@ -132,8 +132,8 @@ func (g *GlobalConf) Parse() {
 				return
 			}
 
-			val := getEnv(g.EnvPrefix, name, f.Name)
-			if val != "" {
+			val, exists := getEnv(g.EnvPrefix, name, f.Name)
+			if exists {
 				set.Set(f.Name, val)
 				return
 			}
@@ -156,10 +156,10 @@ func (g *GlobalConf) ParseAll() {
 }
 
 // Looks up variable in environment
-func getEnv(envPrefix, flagSetName, flagName string) string {
+func getEnv(envPrefix, flagSetName, flagName string) (string, bool) {
 	// If we haven't set an EnvPrefix, don't lookup vals in the ENV
 	if envPrefix == "" {
-		return ""
+		return "", false
 	}
 	// Append a _ to flagSetName if it exists.
 	if flagSetName != "" {
@@ -168,10 +168,10 @@ func getEnv(envPrefix, flagSetName, flagName string) string {
 	flagName = strings.Replace(flagName, ".", "_", -1)
 	flagName = strings.Replace(flagName, "-", "_", -1)
 	envKey := strings.ToUpper(envPrefix + flagSetName + flagName)
-	return os.Getenv(envKey)
+	return os.LookupEnv(envKey)
 }
 
-// Registers a flag set to be parsed. Register all flag sets
+// Register register a flag set to be parsed. Register all flag sets
 // before calling this function. flag.CommandLine is automatically
 // registered.
 func Register(flagSetName string, set *flag.FlagSet) {

--- a/globalconf_test.go
+++ b/globalconf_test.go
@@ -96,6 +96,27 @@ func TestParse_GlobalWithDottedFlagname(t *testing.T) {
 	}
 }
 
+func TestParse_GlobalWithEmptyValue(t *testing.T) {
+	t.Log("Given the need to test overwriting a flag with an environmental variable set to an empty string")
+	t.Log("\tReset the flags and clear the env")
+	{
+		resetForTesting("")
+	}
+
+	t.Log("\tSet the env var for the c flag to an empty string")
+	os.Setenv(envTestPrefix+"C", "")
+	t.Log("\tDefine the c flag and parse the INI file")
+	{
+		flagC := flag.String("c", "", "")
+
+		parse(t, "./testdata/global.ini", "")
+		t.Log("\t\tExpect flagC to an empty string and not be the value Hello World from the INI file")
+		if *flagC != "" {
+			t.Errorf("\t\tflagC found %v, expected an empty string", *flagC)
+		}
+	}
+}
+
 func TestParse_GlobalOverwrite(t *testing.T) {
 	resetForTesting("-b=7.6")
 	flagB := flag.Float64("b", 0.0, "")

--- a/globalconf_test.go
+++ b/globalconf_test.go
@@ -96,24 +96,19 @@ func TestParse_GlobalWithDottedFlagname(t *testing.T) {
 	}
 }
 
+// Given the need to test overwriting a flag with an environmental variable set to an empty string
+// Reset the flags and clear the env.
+// Set the env var for the c flag to an empty string.
+// Expect flagC to an empty string and not be the value Hello World from the INI file.
 func TestParse_GlobalWithEmptyValue(t *testing.T) {
-	t.Log("Given the need to test overwriting a flag with an environmental variable set to an empty string")
-	t.Log("\tReset the flags and clear the env")
-	{
-		resetForTesting("")
-	}
+	resetForTesting("")
 
-	t.Log("\tSet the env var for the c flag to an empty string")
 	os.Setenv(envTestPrefix+"C", "")
-	t.Log("\tDefine the c flag and parse the INI file")
-	{
-		flagC := flag.String("c", "", "")
+	flagC := flag.String("c", "", "")
 
-		parse(t, "./testdata/global.ini", envTestPrefix)
-		t.Log("\t\tExpect flagC to an empty string and not be the value Hello World from the INI file")
-		if *flagC != "" {
-			t.Errorf("\t\tflagC found %v, expected an empty string", *flagC)
-		}
+	parse(t, "./testdata/global.ini", envTestPrefix)
+	if got, want := *flagC, ""; got != want {
+		t.Errorf("got flag = %q, want empty string", got)
 	}
 }
 

--- a/globalconf_test.go
+++ b/globalconf_test.go
@@ -109,7 +109,7 @@ func TestParse_GlobalWithEmptyValue(t *testing.T) {
 	{
 		flagC := flag.String("c", "", "")
 
-		parse(t, "./testdata/global.ini", "")
+		parse(t, "./testdata/global.ini", envTestPrefix)
 		t.Log("\t\tExpect flagC to an empty string and not be the value Hello World from the INI file")
 		if *flagC != "" {
 			t.Errorf("\t\tflagC found %v, expected an empty string", *flagC)


### PR DESCRIPTION
Previously, If you set an environmental variable that matches an `ENVPREFIX_FLAG_NAME` to an empty string, it would not overwrite the flag_name in the INI file.  This uses `os.LookupEnv` to overwrite the flag if it is set at all.

Addresses #16 
