### PR TITLE
Changing EnvPrefix value to match environment variable below

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Command line flags will override the environment variables.
 
 ~~~ go
 opts := globalconf.Options{
-	EnvPrefix: "MYAPP_",
+	EnvPrefix: "APPCONF_",
 	Filename:  "/path/to/config",
 }
 conf, err := globalconf.NewWithOptions(&opts)


### PR DESCRIPTION
I believe that `EnvPrefix` needs to be set to `APPCONF_` for this to work with the proposed environment variable below, `APPCONF_NAME`.